### PR TITLE
Add case restoration for named entities.

### DIFF
--- a/ohnomore/Cargo.toml
+++ b/ohnomore/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.1.0"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 
 [dependencies]
+caseless = "0.2"
 conllx = { git = "https://github.com/danieldk/conllx-rs" }
 error-chain = "0.11"
 fst = "0.3"
 lazy_static = "1.0"
 maplit = "1.0"
 petgraph = "0.4"
+seqalign = "0.1"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.5"

--- a/ohnomore/src/lib.rs
+++ b/ohnomore/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate caseless;
+
 extern crate conllx;
 
 extern crate fst;
@@ -9,6 +11,10 @@ extern crate lazy_static;
 extern crate maplit;
 
 extern crate petgraph;
+
+extern crate seqalign;
+
+extern crate unicode_normalization;
 
 pub mod automaton;
 

--- a/ohnomore/src/transform/lemmatization.rs
+++ b/ohnomore/src/transform/lemmatization.rs
@@ -15,6 +15,7 @@ use constants::*;
 use error::*;
 use transform::auxpassiv::{ancestor_path, verb_lemma_tag, VerbLemmaTag};
 use transform::{DependencyGraph, Token, Transform};
+use transform::named_entity::restore_named_entity_case;
 use transform::svp::longest_prefixes;
 
 /// Add auxililary/passive markers.
@@ -301,6 +302,8 @@ where
 
         if token.tag() == NOUN_TAG {
             uppercase_first_char(token.lemma())
+        } else if token.tag() == NAMED_ENTITY_TAG {
+            restore_named_entity_case(token.form(), token.lemma())
         } else {
             token.lemma().to_owned()
         }

--- a/ohnomore/src/transform/mod.rs
+++ b/ohnomore/src/transform/mod.rs
@@ -73,6 +73,8 @@ pub mod lemmatization;
 
 pub mod misc;
 
+mod named_entity;
+
 mod svp;
 
 #[cfg(test)]

--- a/ohnomore/src/transform/named_entity.rs
+++ b/ohnomore/src/transform/named_entity.rs
@@ -1,0 +1,139 @@
+use std::iter;
+use std::iter::FromIterator;
+
+use caseless::Caseless;
+use seqalign::{Align, Measure, SeqPair};
+use seqalign::op::{archetype, Operation};
+use unicode_normalization::UnicodeNormalization;
+
+/// Levenshtein distance with case a case-insensitive match operation.
+#[derive(Clone, Debug)]
+struct CaseInsensitiveLevenshtein {
+    ops: [CaseInsensitiveLevenshteinOp; 4],
+}
+
+impl CaseInsensitiveLevenshtein {
+    /// Construct a Levenshtein measure with the associated insertion, deletion,
+    /// and substitution cost.
+    pub fn new(insert_cost: usize, delete_cost: usize, substitute_cost: usize) -> Self {
+        use self::CaseInsensitiveLevenshteinOp::*;
+
+        CaseInsensitiveLevenshtein {
+            ops: [
+                Insert(insert_cost),
+                Delete(delete_cost),
+                Match,
+                Substitute(substitute_cost),
+            ],
+        }
+    }
+}
+
+impl Measure<char> for CaseInsensitiveLevenshtein {
+    type Operation = CaseInsensitiveLevenshteinOp;
+
+    fn operations(&self) -> &[Self::Operation] {
+        &self.ops
+    }
+}
+
+/// Case-insensitive Levenshtein operation with associated cost.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum CaseInsensitiveLevenshteinOp {
+    Insert(usize),
+    Delete(usize),
+    Match,
+    Substitute(usize),
+}
+
+impl Operation<char> for CaseInsensitiveLevenshteinOp {
+    fn backtrack(
+        &self,
+        seq_pair: &SeqPair<char>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<(usize, usize)> {
+        use self::CaseInsensitiveLevenshteinOp::*;
+
+        match *self {
+            Delete(cost) => archetype::Delete(cost).backtrack(seq_pair, source_idx, target_idx),
+            Insert(cost) => archetype::Insert(cost).backtrack(seq_pair, source_idx, target_idx),
+            Match => archetype::Match.backtrack(seq_pair, source_idx, target_idx),
+            Substitute(cost) => {
+                archetype::Substitute(cost).backtrack(seq_pair, source_idx, target_idx)
+            }
+        }
+    }
+
+    fn cost(
+        &self,
+        seq_pair: &SeqPair<char>,
+        cost_matrix: &Vec<Vec<usize>>,
+        source_idx: usize,
+        target_idx: usize,
+    ) -> Option<usize> {
+        use self::CaseInsensitiveLevenshteinOp::*;
+
+        let (from_source_idx, from_target_idx) = self.backtrack(seq_pair, source_idx, target_idx)?;
+        let orig_cost = cost_matrix[from_source_idx][from_target_idx];
+
+        match *self {
+            Delete(cost) => {
+                archetype::Delete(cost).cost(seq_pair, cost_matrix, source_idx, target_idx)
+            }
+            Insert(cost) => {
+                archetype::Insert(cost).cost(seq_pair, cost_matrix, source_idx, target_idx)
+            }
+            Match => {
+                if iter::once(seq_pair.source[from_source_idx])
+                    .default_caseless_match(iter::once(seq_pair.target[from_target_idx]))
+                {
+                    Some(orig_cost)
+                } else {
+                    None
+                }
+            }
+            Substitute(cost) => {
+                archetype::Substitute(cost).cost(seq_pair, cost_matrix, source_idx, target_idx)
+            }
+        }
+    }
+}
+
+/// This function restores uppercase characters in lowercased lemmas from
+/// the corresponding forms. This task is actually more complex than it
+/// may seem initially due to the properties of Unicode. In particular:
+///
+/// * Many characters have code points in Unicode, but can also be formed
+///   using composed codepoints (e.g. characters with diacritics such as
+///   ë). This function applies Normalization Form C to ensure the equivalent
+///   representation of characters in the two strings.
+/// * Uppercasing or lowercasing a character that is a single code point may
+///   result in multiple codepoints. In particular, 'ẞ' (upercased sz) can be
+///   lowercased to 'ß' (simple case folding) or 'ss' (full case fulding).
+///   This is partially handled --- individual codepoints are compared using
+///   Unicode caseless matching. However, if a character is 1 codepoint in
+///   the form and >1 codepoint in the lemma (e.g. ẞ vs. ss) or vice versa,
+///   the characters will not be matched.
+pub(crate) fn restore_named_entity_case<S1, S2>(form: S1, lemma: S2) -> String
+where
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+{
+    // Get code points after NFC normalization.
+    let form_chars: Vec<char> = form.as_ref().nfc().collect();
+    let mut lemma_chars: Vec<char> = lemma.as_ref().nfc().collect();
+
+    // Align the strings using case-insensitive Levenshtein distance.
+    let levenshtein = CaseInsensitiveLevenshtein::new(1, 1, 1);
+    let script = levenshtein.align(&form_chars, &lemma_chars).edit_script();
+
+    // Copy over aligned characters from the form to the lemma.
+    for op in script {
+        if let &CaseInsensitiveLevenshteinOp::Match = op.operation() {
+            lemma_chars[op.target_idx()] = form_chars[op.source_idx()];
+        }
+    }
+
+    String::from_iter(lemma_chars)
+}

--- a/ohnomore/testdata/restore-case.test
+++ b/ohnomore/testdata/restore-case.test
@@ -5,5 +5,22 @@
 _ bett NN Bett
 _ Bett NN Bett
 
+# Named entities
+Apple       apple     NE Apple
+Apple's     apple     NE Apple
+Italiens    italien   NE Italien
+Liga-Chef   liga-chef NE Liga-Chef
+Liga-Chef's liga-chef NE Liga-Chef
+LigaChef's  liga-chef NE Liga-Chef
+D'Alema     d'alema   NE D'Alema
+CDU         cdu       NE CDU
+CDU's       cdu       NE CDU
+foobar      cdu       NE cdu
+
+# Check that strings are normalized. The form containes the composed
+# character u0065 u0308, rather than u00eb.
+Ëee ëee NE Ëee
+
 # For other tags, nothing changes.
-_ laufen VVFIN laufen
+_      laufen VVFIN laufen
+Laufen laufen VVFIN laufen


### PR DESCRIPTION
Named entity lemmas are not always identical to their forms:

- The forms may have possesive endings:

  Hollywoods -> Hollywood
  Stach's -> Stach
  Meadows' -> Meadows

- Plural endings:

  Sparkassen -> Sparkasse

- The lemmas sometimes have some normalization.

  O-Shea -> O'Shea
  Milosevicz -> Milosevic

Also note that we cannot simply uppercase the first letter of the
lemma as with nouns (ibm -> Ibm, o'shea -> O'shea). Instead, we use
the following procedure:

- We align the form and the lemma with case-insensitive character
  matches.
- We copy over the characters from the form for the maching characters.