### PR TITLE
FormAsLemma: preserve case in foreign words

### DIFF
--- a/ohnomore/src/constants.rs
+++ b/ohnomore/src/constants.rs
@@ -56,7 +56,6 @@ lazy_static! {
         "APPR",
         "APPO",
         "APZR",
-        "FM",
         "ITJ",
         "KOUI",
         "KOUS",
@@ -67,6 +66,10 @@ lazy_static! {
         "PTKZU",
         "PTKA",
         "PTKNEG",
+    };
+
+    pub static ref LEMMA_IS_FORM_PRESERVE_CASE_TAGS: HashSet<&'static str> = hashset! {
+        FOREIGN_WORD_TAG,
     };
 
     /// Part-of-speech tags that have special (non-word) lemmas.

--- a/ohnomore/src/transform/lemmatization.rs
+++ b/ohnomore/src/transform/lemmatization.rs
@@ -178,6 +178,8 @@ where
         // Handle tags for which the lemma is the lowercased form.
         if LEMMA_IS_FORM_TAGS.contains(token.tag()) {
             token.form().to_lowercase()
+        } else if LEMMA_IS_FORM_PRESERVE_CASE_TAGS.contains(token.tag()) {
+            token.form().to_owned()
         } else {
             token.lemma().to_owned()
         }

--- a/ohnomore/testdata/form-as-lemma.test
+++ b/ohnomore/testdata/form-as-lemma.test
@@ -5,6 +5,10 @@
 und _ KON und
 Und _ KON und
 
+# Foreign words should use the form, retaining case.
+Brasil _ FM Brasil
+improve _ FM improve
+
 # For other tags, nothing changes.
 Auto Foobar NN Foobar
 NBA  Quux   NE Quux


### PR DESCRIPTION
This seems to generally lead to better results. If a foreign word is
capitalized, it is often a foreign name, which we do not want to
lowercase. This also seems to be the policy in TüBa-D/Z.