### PR TITLE
Improve handling of reflexive personal pronouns

### DIFF
--- a/ohnomore-utils/src/bin/ohnomore-postproc.rs
+++ b/ohnomore-utils/src/bin/ohnomore-postproc.rs
@@ -5,7 +5,8 @@ use std::io::{BufReader, BufWriter};
 use conllu::io::{Reader, WriteSentence, Writer};
 use getopts::Options;
 use ohnomore::transform::lemmatization::{
-    AddSeparatedVerbPrefix, FormAsLemma, MarkVerbPrefix, ReadVerbPrefixes, RestoreCase,
+    AddReflexiveTag, AddSeparatedVerbPrefix, FormAsLemma, MarkVerbPrefix, ReadVerbPrefixes,
+    RestoreCase,
 };
 use ohnomore::transform::misc::{
     SimplifyArticleLemma, SimplifyPIAT, SimplifyPIDAT, SimplifyPIS, SimplifyPossesivePronounLemma,
@@ -50,6 +51,7 @@ fn main() {
     let transforms = Transforms(vec![
         Box::new(FormAsLemma),
         Box::new(RestoreCase),
+        Box::new(AddReflexiveTag),
         Box::new(AddSeparatedVerbPrefix::new(true)),
         Box::new(prefix_transform),
         Box::new(SimplifyArticleLemma),

--- a/ohnomore/src/transform/delemmatization.rs
+++ b/ohnomore/src/transform/delemmatization.rs
@@ -43,9 +43,7 @@ impl Transform for RemoveReflexiveTag {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if token.tag() == REFLEXIVE_PERSONAL_PRONOUN_TAG
-            && lemma == REFLEXIVE_PERSONAL_PRONOUN_LEMMA
-        {
+        if token.tag() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
             return token.form().to_lowercase();
         }
 

--- a/ohnomore/src/transform/lemmatization.rs
+++ b/ohnomore/src/transform/lemmatization.rs
@@ -14,6 +14,22 @@ use crate::transform::named_entity::restore_named_entity_case;
 use crate::transform::svp::longest_prefixes;
 use crate::transform::{DependencyGraph, Transform};
 
+/// Set the lemma of reflexive personal pronouns (PRF) to `#refl`.
+pub struct AddReflexiveTag;
+
+impl Transform for AddReflexiveTag {
+    fn transform(&self, graph: &dyn DependencyGraph, node: usize) -> String {
+        let token = graph.token(node);
+        let lemma = token.lemma();
+
+        if token.tag() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
+            REFLEXIVE_PERSONAL_PRONOUN_LEMMA.to_owned()
+        } else {
+            lemma.to_owned()
+        }
+    }
+}
+
 /// Add separable verb prefixes to verbs.
 ///
 /// TüBa-D/Z marks separable verb prefixes in the verb lemma. E.g. *ab#zeichnen*,


### PR DESCRIPTION
- Fix delemmatization transformation. This relied on the gold standard
  data using the lemma `#refl`. This is, however, not used used in the
  UD version of TüBa-D/Z.
- Add a lemmatization transformation, that replaces the lemma by
  `#refl`.