### PR TITLE
Allow use of CoNLL-U UPOS and XPOS in transformations

### DIFF
--- a/ohnomore/src/transform/delemmatization.rs
+++ b/ohnomore/src/transform/delemmatization.rs
@@ -17,9 +17,9 @@ impl Transform for RemoveAlternatives {
         let token = graph.token(node);
         let mut lemma = token.lemma();
 
-        if token.tag().starts_with(PUNCTUATION_PREFIX)
-            || token.tag() == NON_WORD_TAG
-            || token.tag() == FOREIGN_WORD_TAG
+        if token.xpos().starts_with(PUNCTUATION_PREFIX)
+            || token.xpos() == NON_WORD_TAG
+            || token.xpos() == FOREIGN_WORD_TAG
         {
             return lemma.to_owned();
         }
@@ -43,7 +43,7 @@ impl Transform for RemoveReflexiveTag {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if token.tag() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
+        if token.xpos() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
             return token.form().to_lowercase();
         }
 
@@ -64,7 +64,7 @@ impl Transform for RemoveSepVerbPrefix {
         let token = graph.token(node);
         let mut lemma = token.lemma();
 
-        if is_verb(token.tag()) {
+        if is_verb(token.xpos()) {
             if let Some(idx) = lemma.rfind('#') {
                 lemma = &lemma[idx + 1..];
             }
@@ -94,7 +94,7 @@ impl Transform for RemoveTruncMarker {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if token.tag() == TRUNCATED_TAG {
+        if token.xpos() == TRUNCATED_TAG {
             if let Some(idx) = lemma.rfind('%') {
                 let tag = &lemma[idx + 1..];
 

--- a/ohnomore/src/transform/lemmatization.rs
+++ b/ohnomore/src/transform/lemmatization.rs
@@ -22,7 +22,7 @@ impl Transform for AddReflexiveTag {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if token.tag() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
+        if token.xpos() == REFLEXIVE_PERSONAL_PRONOUN_TAG {
             REFLEXIVE_PERSONAL_PRONOUN_LEMMA.to_owned()
         } else {
             lemma.to_owned()
@@ -61,7 +61,7 @@ impl Transform for AddSeparatedVerbPrefix {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if !is_separable_verb(token.tag()) {
+        if !is_separable_verb(token.xpos()) {
             return lemma.to_owned();
         }
 
@@ -74,7 +74,7 @@ impl Transform for AddSeparatedVerbPrefix {
         // Fixme: what about particles linked KON?
         let mut prefix_iter = graph
             .dependents(node)
-            .filter(|(dependent, _)| graph.token(*dependent).tag() == SEPARABLE_PARTICLE_POS);
+            .filter(|(dependent, _)| graph.token(*dependent).xpos() == SEPARABLE_PARTICLE_POS);
 
         if self.multiple_prefixes {
             let mut lemmas = Vec::new();
@@ -109,9 +109,9 @@ impl Transform for FormAsLemma {
         let token = graph.token(node);
 
         // Handle tags for which the lemma is the lowercased form.
-        if LEMMA_IS_FORM_TAGS.contains(token.tag()) {
+        if LEMMA_IS_FORM_TAGS.contains(token.xpos()) {
             token.form().to_lowercase()
-        } else if LEMMA_IS_FORM_PRESERVE_CASE_TAGS.contains(token.tag()) {
+        } else if LEMMA_IS_FORM_PRESERVE_CASE_TAGS.contains(token.xpos()) {
             token.form().to_owned()
         } else {
             token.lemma().to_owned()
@@ -172,7 +172,7 @@ impl Transform for MarkVerbPrefix {
         let lemma = token.lemma();
         let lemma_lc = lemma.to_lowercase();
 
-        if !is_verb(token.tag()) {
+        if !is_verb(token.xpos()) {
             return lemma.to_owned();
         }
 
@@ -193,7 +193,7 @@ impl Transform for MarkVerbPrefix {
         // Case 2: there are no prefixes in the lemma, try to find prefixes
         // in the form.
         let form_lc = token.form().to_lowercase();
-        let mut lemma_parts = longest_prefixes(&self.prefixes, &form_lc, &lemma_lc, token.tag());
+        let mut lemma_parts = longest_prefixes(&self.prefixes, &form_lc, &lemma_lc, token.xpos());
         if !lemma_parts.is_empty() {
             lemma_parts.push(lemma_lc);
             return lemma_parts.join("#");
@@ -238,9 +238,9 @@ impl Transform for RestoreCase {
     fn transform(&self, graph: &dyn DependencyGraph, node: usize) -> String {
         let token = graph.token(node);
 
-        if token.tag() == NOUN_TAG {
+        if token.xpos() == NOUN_TAG {
             uppercase_first_char(token.lemma())
-        } else if token.tag() == NAMED_ENTITY_TAG {
+        } else if token.xpos() == NAMED_ENTITY_TAG {
             restore_named_entity_case(token.form(), token.lemma())
         } else {
             token.lemma().to_owned()

--- a/ohnomore/src/transform/misc.rs
+++ b/ohnomore/src/transform/misc.rs
@@ -28,7 +28,7 @@ impl Transform for SimplifyArticleLemma {
         let token = graph.token(node);
         let lemma = token.lemma();
         let form = token.form();
-        let tag = token.tag();
+        let tag = token.xpos();
 
         if tag == ARTICLE_TAG || tag == SUBST_REL_PRONOUN || tag == ATTR_REL_PRONOUN {
             if form.to_lowercase().starts_with('d') {
@@ -79,7 +79,7 @@ impl Transform for SimplifyPIAT {
         let token = graph.token(node);
         let lemma = token.lemma();
         let form = token.form();
-        let tag = token.tag();
+        let tag = token.xpos();
 
         if tag != ATTRIBUTING_INDEF_PRONOUN_WITHOUT_DET {
             return lemma.to_owned();
@@ -146,7 +146,7 @@ impl Transform for SimplifyPIDAT {
         let token = graph.token(node);
         let lemma = token.lemma();
         let form = token.form();
-        let tag = token.tag();
+        let tag = token.xpos();
 
         if tag != ATTRIBUTING_INDEF_PRONOUN_WITH_DET {
             return lemma.to_owned();
@@ -215,7 +215,7 @@ impl Transform for SimplifyPIS {
         let token = graph.token(node);
         let lemma = token.lemma();
         let form = token.form();
-        let tag = token.tag();
+        let tag = token.xpos();
 
         if tag != SUBSTITUTING_INDEF_PRONOUN {
             return lemma.to_owned();
@@ -288,7 +288,7 @@ pub struct SimplifyPersonalPronounLemma;
 impl Transform for SimplifyPersonalPronounLemma {
     fn transform(&self, graph: &dyn DependencyGraph, node: usize) -> String {
         let token = graph.token(node);
-        let tag = token.tag();
+        let tag = token.xpos();
         let lemma = token.lemma();
 
         if tag != PERSONAL_PRONOUN_TAG {
@@ -323,7 +323,7 @@ pub struct SimplifyPossesivePronounLemma;
 impl Transform for SimplifyPossesivePronounLemma {
     fn transform(&self, graph: &dyn DependencyGraph, node: usize) -> String {
         let token = graph.token(node);
-        let tag = token.tag();
+        let tag = token.xpos();
         let form = token.form();
         let lemma = token.lemma();
 

--- a/ohnomore/src/transform/mod.rs
+++ b/ohnomore/src/transform/mod.rs
@@ -48,7 +48,8 @@ pub trait TokenMut: Token {
 pub trait Token {
     fn form(&self) -> &str;
     fn lemma(&self) -> &str;
-    fn tag(&self) -> &str;
+    fn upos(&self) -> &str;
+    fn xpos(&self) -> &str;
 }
 
 impl Token for conllu::token::Token {
@@ -60,7 +61,11 @@ impl Token for conllu::token::Token {
         self.lemma().unwrap_or("_")
     }
 
-    fn tag(&self) -> &str {
+    fn upos(&self) -> &str {
+        self.upos().unwrap()
+    }
+
+    fn xpos(&self) -> &str {
         self.xpos().unwrap()
     }
 }

--- a/ohnomore/src/transform/test_helpers.rs
+++ b/ohnomore/src/transform/test_helpers.rs
@@ -41,7 +41,8 @@ impl DependencyGraph for TestCaseGraph {
 pub struct TestToken {
     form: String,
     lemma: String,
-    tag: String,
+    upos: String,
+    xpos: String,
 }
 
 impl Token for TestToken {
@@ -53,8 +54,12 @@ impl Token for TestToken {
         &self.lemma
     }
 
-    fn tag(&self) -> &str {
-        &self.tag
+    fn upos(&self) -> &str {
+        &self.upos
+    }
+
+    fn xpos(&self) -> &str {
+        &self.xpos
     }
 }
 
@@ -79,7 +84,8 @@ fn read_token(iter: &mut dyn Iterator<Item = &str>) -> Option<TestToken> {
     Some(TestToken {
         form: iter.next()?.to_owned(),
         lemma: iter.next()?.to_owned(),
-        tag: iter.next()?.to_owned(),
+        upos: iter.next()?.to_owned(),
+        xpos: iter.next()?.to_owned(),
     })
 }
 
@@ -110,12 +116,16 @@ where
         graph.add_node(TestToken {
             form: "ROOT".to_string(),
             lemma: "ROOT".to_string(),
-            tag: "ROOT".to_string(),
+            upos: "root".to_string(),
+            xpos: "root".to_string(),
         });
 
         let test_token = read_token(&mut iter).unwrap();
         let index = graph.add_node(test_token);
-        let correct = iter.next().expect("Gold standard lemma missing").to_owned();
+        let correct = iter
+            .next()
+            .expect(&format!("Gold standard lemma missing: {}", line_str))
+            .to_owned();
 
         // Optional: read head
         if let Some((rel, head)) = read_dependency(&mut iter) {

--- a/ohnomore/testdata/add-separated-verb-prefix.test
+++ b/ohnomore/testdata/add-separated-verb-prefix.test
@@ -1,18 +1,18 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Single separated prefix
-_ zeichnen VVFIN ab#zeichnen _ _ _ _ AVZ ab   _ PTKVZ
-_ zeichnen VVFIN ab#zeichnen _ _ _ _ AVZ Ab   _ PTKVZ
-_ stellen  VVFIN vor#stellen _ _ _ _ AVZ vor  _ PTKVZ
-_ müssen   VVFIN rein#müssen _ _ _ _ AVZ rein _ PTKVZ
-_ werden   VVFIN los#werden  _ _ _ _ AVZ los  _ PTKVZ
+_ zeichnen _ VVFIN ab#zeichnen _ _ _ _ _ AVZ ab   _ _ PTKVZ
+_ zeichnen _ VVFIN ab#zeichnen _ _ _ _ _ AVZ Ab   _ _ PTKVZ
+_ stellen  _ VVFIN vor#stellen _ _ _ _ _ AVZ vor  _ _ PTKVZ
+_ müssen   _ VVFIN rein#müssen _ _ _ _ _ AVZ rein _ _ PTKVZ
+_ werden   _ VVFIN los#werden  _ _ _ _ _ AVZ los  _ _ PTKVZ
 
 # Multiple separated prefixes
-_ nehmen VVFIN zu#nehmen|ab#nehmen _ _ _ _ AVZ ab _ PTKVZ KON zu _ PTKVZ
+_ nehmen _ VVFIN zu#nehmen|ab#nehmen _ _ _ _ _ AVZ ab _ _ PTKVZ KON zu _ _ PTKVZ
 
 # No splitting necessary
-kommt kommen VVFIN kommen
+kommt kommen _ VVFIN kommen
 
 # Not all tags can have separated prefixes.
-_ zeichnen VVINF zeichnen _ _ _ _ AVZ ab _ PTKVZ
+_ zeichnen _ VVINF zeichnen _ _ _ _ _ AVZ ab _ _ PTKVZ

--- a/ohnomore/testdata/form-as-lemma.test
+++ b/ohnomore/testdata/form-as-lemma.test
@@ -1,14 +1,14 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # For applicable tags, the lemma is the lowercase form.
-und _ KON und
-Und _ KON und
+und _ _ KON und
+Und _ _ KON und
 
 # Foreign words should use the form, retaining case.
-Brasil _ FM Brasil
-improve _ FM improve
+Brasil _ _ FM Brasil
+improve _ _ FM improve
 
 # For other tags, nothing changes.
-Auto Foobar NN Foobar
-NBA  Quux   NE Quux
+Auto Foobar _ NN Foobar
+NBA  Quux   _ NE Quux

--- a/ohnomore/testdata/mark-verb-prefix.test
+++ b/ohnomore/testdata/mark-verb-prefix.test
@@ -1,26 +1,26 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Lookup table
-_ abbestellen VVFIN ab#bestellen
+_ abbestellen _ VVFIN ab#bestellen
 
 # Derive from form
-dazugefügt       fügen    VVFIN dazu#fügen
-wiedergutgemacht machen   VVFIN wieder#gut#machen
-abzuarbeiten     arbeiten VVIZU ab#arbeiten
-abgefangen       fangen   VVPP  ab#fangen
-abhing           hängen   VVFIN ab#hängen
+dazugefügt       fügen    _ VVFIN dazu#fügen
+wiedergutgemacht machen   _ VVFIN wieder#gut#machen
+abzuarbeiten     arbeiten _ VVIZU ab#arbeiten
+abgefangen       fangen   _ VVPP  ab#fangen
+abhing           hängen   _ VVFIN ab#hängen
 
 # Multiple prefixes
-mitabgedruckt drucken VVFIN mit#ab#drucken
+mitabgedruckt drucken _ VVFIN mit#ab#drucken
 
 # 'zustande' is a particle, so here we do not want to match the
 # longest common prefix.
-zustanden        stehen   VVFIN zu#stehen
+zustanden        stehen   _ VVFIN zu#stehen
 
 # 'hinzu' is a particle, check that we don't analysze as 'hinzu#bewegen'
-hinzubewegen   bewegen VVIZU hin#bewegen
-zuzuspitzen    spitzen VVIZU zu#spitzen
-hinzuwirken    wirken  VVIZU hin#wirken
-hinzuzufügen   fügen   VVIZU hinzu#fügen
-mitaufzunehmen nehmen  VVIZU mit#auf#nehmen
+hinzubewegen   bewegen _ VVIZU hin#bewegen
+zuzuspitzen    spitzen _ VVIZU zu#spitzen
+hinzuwirken    wirken  _ VVIZU hin#wirken
+hinzuzufügen   fügen   _ VVIZU hinzu#fügen
+mitaufzunehmen nehmen  _ VVIZU mit#auf#nehmen

--- a/ohnomore/testdata/remove-sep-verb-prefix.test
+++ b/ohnomore/testdata/remove-sep-verb-prefix.test
@@ -1,11 +1,11 @@
-# Format: form lemma pos transformed
+# Format: form lemma upos xpos transformed
 
 # Should be stripped
-_ hinein#ziehen   VVPP  ziehen
-_ zusammen#hängen VVFIN hängen
+_ hinein#ziehen   _ VVPP  ziehen
+_ zusammen#hängen _ VVFIN hängen
 
 # Multiple prefixes
-_ wieder#auf#bauen VVINF bauen
+_ wieder#auf#bauen _ VVINF bauen
 
 # No changes for non-verbs
-_ CD#1 NN CD#1
+_ CD#1 _ NN CD#1

--- a/ohnomore/testdata/remove-trunc-marker.test
+++ b/ohnomore/testdata/remove-trunc-marker.test
@@ -1,10 +1,10 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
-Bau-   Bauplanung%n   TRUNC Bau-
-jahre- jahrelang%a    TRUNC jahre-
-Jahre- jahrelang%a    TRUNC jahre-
-hin-   hin#schieben%v TRUNC hin-
+Bau-   Bauplanung%n   _ TRUNC Bau-
+jahre- jahrelang%a    _ TRUNC jahre-
+Jahre- jahrelang%a    _ TRUNC jahre-
+hin-   hin#schieben%v _ TRUNC hin-
 
 # Should not fire for other tags
-Bau- Bauplanung%n XYZ Bauplanung%n
+Bau- Bauplanung%n _ XYZ Bauplanung%n

--- a/ohnomore/testdata/restore-case.test
+++ b/ohnomore/testdata/restore-case.test
@@ -1,26 +1,26 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Nouns should have uppercased initial letters.
-_ bett NN Bett
-_ Bett NN Bett
+_ bett _ NN Bett
+_ Bett _ NN Bett
 
 # Named entities
-Apple       apple     NE Apple
-Apple's     apple     NE Apple
-Italiens    italien   NE Italien
-Liga-Chef   liga-chef NE Liga-Chef
-Liga-Chef's liga-chef NE Liga-Chef
-LigaChef's  liga-chef NE Liga-Chef
-D'Alema     d'alema   NE D'Alema
-CDU         cdu       NE CDU
-CDU's       cdu       NE CDU
-foobar      cdu       NE cdu
+Apple       apple     _ NE Apple
+Apple's     apple     _ NE Apple
+Italiens    italien   _ NE Italien
+Liga-Chef   liga-chef _ NE Liga-Chef
+Liga-Chef's liga-chef _ NE Liga-Chef
+LigaChef's  liga-chef _ NE Liga-Chef
+D'Alema     d'alema   _ NE D'Alema
+CDU         cdu       _ NE CDU
+CDU's       cdu       _ NE CDU
+foobar      cdu       _ NE cdu
 
 # Check that strings are normalized. The form containes the composed
 # character u0065 u0308, rather than u00eb.
-Ëee ëee NE Ëee
+Ëee ëee _ NE Ëee
 
 # For other tags, nothing changes.
-_      laufen VVFIN laufen
-Laufen laufen VVFIN laufen
+_      laufen _ VVFIN laufen
+Laufen laufen _ VVFIN laufen

--- a/ohnomore/testdata/simplify-article-lemma.test
+++ b/ohnomore/testdata/simplify-article-lemma.test
@@ -1,31 +1,31 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Definite articles are lemmatized to 'd'
-der _ ART d
-des _ ART d
-dem _ ART d
-den _ ART d
-die _ ART d
-das _ ART d
+der _ _ ART d
+des _ _ ART d
+dem _ _ ART d
+den _ _ ART d
+die _ _ ART d
+das _ _ ART d
 
 # Indefinite articles are lemmatized to 'e'
-ein   _ ART e
-eines _ ART e
-einem _ ART e
-einen _ ART e
-eine  _ ART e
-einer _ ART e
+ein   _ _ ART e
+eines _ _ ART e
+einem _ _ ART e
+einen _ _ ART e
+eine  _ _ ART e
+einer _ _ ART e
 
 # Definite articles are lemmatized to 'd'
-der _ ART d
+der _ _ ART d
 
 # Substituting relative pronoun
-der _ PRELS d
+der _ _ PRELS d
 
 # Attributive relative pronoun
-dessen _ PRELAT d
+dessen _ _ PRELAT d
 
 # Do not attempt to lemmatize words with an irrelevant tag.
-der foo XY foo
-ein bar XY bar
+der foo _ XY foo
+ein bar _ XY bar

--- a/ohnomore/testdata/simplify-personal-pronoun.test
+++ b/ohnomore/testdata/simplify-personal-pronoun.test
@@ -1,34 +1,34 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Personal pronouns
-ich    _ PPER ich
-mir    _ PPER ich
-mich   _ PPER ich
-meiner _ PPER ich
-du     _ PPER du
-dir    _ PPER du
-dich   _ PPER du
-deiner _ PPER du
-er     _ PPER er
-ihn    _ PPER er
-ihm    _ PPER er
-seiner _ PPER er
-sie    _ PPER sie
-ihr    _ PPER sie
-ihnen  _ PPER sie
-ihrer  _ PPER sie
-es     _ PPER es
-'s     _ PPER es
-wir    _ PPER wir
-uns    _ PPER wir
-unser  _ PPER wir
-euch   _ PPER ihr
+ich    _ _ PPER ich
+mir    _ _ PPER ich
+mich   _ _ PPER ich
+meiner _ _ PPER ich
+du     _ _ PPER du
+dir    _ _ PPER du
+dich   _ _ PPER du
+deiner _ _ PPER du
+er     _ _ PPER er
+ihn    _ _ PPER er
+ihm    _ _ PPER er
+seiner _ _ PPER er
+sie    _ _ PPER sie
+ihr    _ _ PPER sie
+ihnen  _ _ PPER sie
+ihrer  _ _ PPER sie
+es     _ _ PPER es
+'s     _ _ PPER es
+wir    _ _ PPER wir
+uns    _ _ PPER wir
+unser  _ _ PPER wir
+euch   _ _ PPER ihr
 
 # Use the lemma when the form is unknown
-ic ich PPER ich
+ic ich _ PPER ich
 
 # Exclude other tags
-ich  foo XY foo
-mir  bar XY bar
-mich baz XY baz
+ich  foo _ XY foo
+mir  bar _ XY bar
+mich baz _ XY baz

--- a/ohnomore/testdata/simplify-piat-lemma.test
+++ b/ohnomore/testdata/simplify-piat-lemma.test
@@ -1,83 +1,83 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
-keinen	kein	PIAT    kein
-keine	kein	PIAT    kein
-mehrere	mehrere	PIAT    mehrere
-mehr	mehr	PIAT    mehr
-kein	kein	PIAT    kein
-einige	einiges	PIAT    einig
-soviel	soviel	PIAT    soviel
-mehreren	mehrere	PIAT    mehrere
-etliche	etliche	PIAT    etlich
-weniger	weniger	PIAT   	wenig
-keiner	keine	PIAT	kein
-manche	mancher	PIAT	manch
-viel	viel	PIAT	viel
-wenig	wenig	PIAT	wenig
-keinerlei	keinerlei	PIAT keinerlei
-irgendwelchen	irgendwelches	PIAT irgendwelch
-einigen	einiger	PIAT	einig
-derlei	derlei	PIAT	derlei
-genausoviel	genausoviel	PIAT	genausoviel
-etwas	etwas	PIAT	etwas
-keinem	kein	PIAT	kein
-#köön	kein_	PIAT	kein
-einigem	einiger	PIAT	einig
-manchen	mancher	PIAT	manch
-manches	manches	PIAT	manch
-sowas	sowas	PIAT	sowas
-einiger	einige	PIAT	einig
-ebensoviel	ebensoviel	PIAT	ebensoviel
-allerhand	allerhand	PIAT	allerhand
-genug	genug	PIAT	genug
-irgendein	irgendein	PIAT	irgendein
-reichlich	reichlich	PIAT	reichlich
-genügend	genügend	PIAT	genügend
-irgendeiner	irgendeine	PIAT	irgendein
-lauter	lauter	PIAT	lauter
-was	etwas	PIAT	etwas
-mancher	mancher	PIAT	manch
-zuviel	zuviel	PIAT	zuviel
-allerlei	allerlei	PIAT	allerlei
-mehrerer	mehrere	PIAT	mehrere
-#kain	kein_	PIAT	kein
-zuwenig	zuwenig	PIAT	zuwenig
-allzuviel	allzuviel	PIAT	allzuviel
-ausreichend	ausreichend	PIAT	ausreichend
-irgendeine	irgendeine	PIAT	irgendein
-keines	kein	PIAT	kein
-dergleichen	dergleichen	PIAT	dergleichen
-#ken	kein	PIAT	kein
-etliches	etliches	PIAT	etlich
-einiges	einiges	PIAT	einig
-irgendwelche	irgendwelche	PIAT	irgendwelch
-gleichviel	gleichviel	PIAT	gleichviel
-etlicher	etliche	PIAT	etlich
-irgendeinem	irgendein	PIAT	irgendein
-zweierlei	zweierlei	PIAT	zweierlei
-etlichen	etliche	PIAT	etlich
-vielerlei	vielerlei	PIAT	vielerlei
-beiderlei	beiderlei	PIAT	beiderlei
-manchem	manches	PIAT	manch
-intertransmultibiviele	intertransmultibiviel	PIAT	intertransmultibiviel
-#mache	manche	PIAT	manch
-mehrer	mehrere	PIAT	mehrere
-irgendwelcher	irgendwelcher	PIAT	irgendwelch
-sowenig	sowenig	PIAT	sowenig
-irgendeinen	irgendein	PIAT	irgendein
-allelei	allerlei	PIAT	allerlei
-genausowenig	genausowenig	PIAT	genausowenig
-solcherlei	solcherlei	PIAT	solcherlei
-irgendeines	irgendein	PIAT	irgendein
-tausenderlei	tausenderlei	PIAT	tausenderlei
-jedwedem	jedweder	PIAT	jedwed
-etwelchen	etwelcher	PIAT	etwelcher
-#keene	keine_	PIAT	kein
-genügnd	genügend_	PIAT	genügend_
-jedwedes	jedwedes	PIAT	jedwed
-jedweder	jedwede	PIAT	jedwed
-jedweden	jedwedes	PIAT	jedwed
-diese	diese	PIAT	diese
-siebenerlei	siebenerlei	PIAT	siebenerlei
-kein(e)	kein	PIAT	kein
+keinen	kein	_	PIAT    kein
+keine	kein	_	PIAT    kein
+mehrere	mehrere	_	PIAT    mehrere
+mehr	mehr	_	PIAT    mehr
+kein	kein	_	PIAT    kein
+einige	einiges	_	PIAT    einig
+soviel	soviel	_	PIAT    soviel
+mehreren	mehrere	_	PIAT    mehrere
+etliche	etliche	_	PIAT    etlich
+weniger	weniger	_	PIAT   	wenig
+keiner	keine	_	PIAT	kein
+manche	mancher	_	PIAT	manch
+viel	viel	_	PIAT	viel
+wenig	wenig	_	PIAT	wenig
+keinerlei	keinerlei	_	PIAT keinerlei
+irgendwelchen	irgendwelches	_	PIAT irgendwelch
+einigen	einiger	_	PIAT	einig
+derlei	derlei	_	PIAT	derlei
+genausoviel	genausoviel	_	PIAT	genausoviel
+etwas	etwas	_	PIAT	etwas
+keinem	kein	_	PIAT	kein
+#köön	kein_	_	PIAT	kein
+einigem	einiger	_	PIAT	einig
+manchen	mancher	_	PIAT	manch
+manches	manches	_	PIAT	manch
+sowas	sowas	_	PIAT	sowas
+einiger	einige	_	PIAT	einig
+ebensoviel	ebensoviel	_	PIAT	ebensoviel
+allerhand	allerhand	_	PIAT	allerhand
+genug	genug	_	PIAT	genug
+irgendein	irgendein	_	PIAT	irgendein
+reichlich	reichlich	_	PIAT	reichlich
+genügend	genügend	_	PIAT	genügend
+irgendeiner	irgendeine	_	PIAT	irgendein
+lauter	lauter	_	PIAT	lauter
+was	etwas	_	PIAT	etwas
+mancher	mancher	_	PIAT	manch
+zuviel	zuviel	_	PIAT	zuviel
+allerlei	allerlei	_	PIAT	allerlei
+mehrerer	mehrere	_	PIAT	mehrere
+#kain	kein_	_	PIAT	kein
+zuwenig	zuwenig	_	PIAT	zuwenig
+allzuviel	allzuviel	_	PIAT	allzuviel
+ausreichend	ausreichend	_	PIAT	ausreichend
+irgendeine	irgendeine	_	PIAT	irgendein
+keines	kein	_	PIAT	kein
+dergleichen	dergleichen	_	PIAT	dergleichen
+#ken	kein	_	PIAT	kein
+etliches	etliches	_	PIAT	etlich
+einiges	einiges	_	PIAT	einig
+irgendwelche	irgendwelche	_	PIAT	irgendwelch
+gleichviel	gleichviel	_	PIAT	gleichviel
+etlicher	etliche	_	PIAT	etlich
+irgendeinem	irgendein	_	PIAT	irgendein
+zweierlei	zweierlei	_	PIAT	zweierlei
+etlichen	etliche	_	PIAT	etlich
+vielerlei	vielerlei	_	PIAT	vielerlei
+beiderlei	beiderlei	_	PIAT	beiderlei
+manchem	manches	_	PIAT	manch
+intertransmultibiviele	intertransmultibiviel	_	PIAT	intertransmultibiviel
+#mache	manche	_	PIAT	manch
+mehrer	mehrere	_	PIAT	mehrere
+irgendwelcher	irgendwelcher	_	PIAT	irgendwelch
+sowenig	sowenig	_	PIAT	sowenig
+irgendeinen	irgendein	_	PIAT	irgendein
+allelei	allerlei	_	PIAT	allerlei
+genausowenig	genausowenig	_	PIAT	genausowenig
+solcherlei	solcherlei	_	PIAT	solcherlei
+irgendeines	irgendein	_	PIAT	irgendein
+tausenderlei	tausenderlei	_	PIAT	tausenderlei
+jedwedem	jedweder	_	PIAT	jedwed
+etwelchen	etwelcher	_	PIAT	etwelcher
+#keene	keine_	_	PIAT	kein
+genügnd	genügend_	_	PIAT	genügend_
+jedwedes	jedwedes	_	PIAT	jedwed
+jedweder	jedwede	_	PIAT	jedwed
+jedweden	jedwedes	_	PIAT	jedwed
+diese	diese	_	PIAT	diese
+siebenerlei	siebenerlei	_	PIAT	siebenerlei
+kein(e)	kein	_	PIAT	kein

--- a/ohnomore/testdata/simplify-pidat-lemma.test
+++ b/ohnomore/testdata/simplify-pidat-lemma.test
@@ -1,101 +1,101 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # all* is lemmatized to 'all'
-alle _ PIDAT all
-aller _ PIDAT all
-all _ PIDAT all
-alle aller PIDAT all
+alle _ _ PIDAT all
+aller _ _ PIDAT all
+all _ _ PIDAT all
+alle aller _ PIDAT all
 
 # ebensolch* is lemmatized to 'ebensolch'
-ebensolcher _ PIDAT ebensolch
-ebensolches _ PIDAT ebensolch
-ebensolchen _ PIDAT ebensolch
-ebensolch _ PIDAT ebensolch
+ebensolcher _ _ PIDAT ebensolch
+ebensolches _ _ PIDAT ebensolch
+ebensolchen _ _ PIDAT ebensolch
+ebensolch _ _ PIDAT ebensolch
 
 # ebensoviel* is lemmatized to 'ebensoviel'
-ebensoviele _ PIDAT ebensoviel
-ebensovielen _ PIDAT ebensoviel
-ebensoviel _ PIDAT ebensoviel
+ebensoviele _ _ PIDAT ebensoviel
+ebensovielen _ _ PIDAT ebensoviel
+ebensoviel _ _ PIDAT ebensoviel
 
 # don't touch words with different tag
-alle foo PIRAT foo
+alle foo _ PIRAT foo
 
 # don't touch words that are lemmatized to the same anyways
-sämtlich sämtlich PIDAT sämtlich
+sämtlich sämtlich _ PIDAT sämtlich
 
 
-# all unique forms for PIDAT
-solche	solche	PIDAT   solch
-viele	viele	PIDAT   viel
-paar	paar	PIDAT   paar
-jeden	jeder	PIDAT   jed
-bißchen	bißchen	PIDAT   bißchen
-vielen	viele	PIDAT   viel
-alle	alle	PIDAT   all
-solch	solch	PIDAT   solch
-all	all	PIDAT   all
-aller	alles	PIDAT   all
-wenigen	wenige	PIDAT   wenig
-jede	jede	PIDAT   jed
-beiden	beide	PIDAT   beide
-jedes	jedes	PIDAT   jed
-jeder	jeder	PIDAT   jed
-beide	beide	PIDAT   beide
-jegliche	jegliche	PIDAT   jeglich
-solcher	solcher	PIDAT   solch
-allen	alle	PIDAT   all
-beider	beide	PIDAT   beide
-vieler	viele	PIDAT   viel
-solchen	solcher	PIDAT   solch
-jedem	jedes	PIDAT   jed
-wenige	wenige	PIDAT   wenig
-alles	alles	PIDAT   all
-meisten	meisten	PIDAT   meist
-solches	solches	PIDAT   solch
-ebensoviele	ebensovieles	PIDAT   ebensoviel
-wenig	wenig	PIDAT   wenig
-sämtliche	sämtlich	PIDAT   sämtlich
-weniger	wenige	PIDAT   wenig
-allem	alles	PIDAT   all
-jede/r	jeder	PIDAT   jed
-jeglichem	jeglicher	PIDAT   jeglich
-jedwede	jedwede	PIDAT   jedwed
-manch	manch	PIDAT   manch
-soviele	sovieles	PIDAT   soviel
-jeglicher	jegliche	PIDAT   jeglich
--zig	zig	PIDAT   zig
-sämtlicher	sämtlich	PIDAT   sämtlich
-jedweder	jedwede	PIDAT   jedwed
-sämtliches	sämtlich	PIDAT   sämtlich
-wenigsten	wenigste	PIDAT   wenigst
-zuviele	zuvieler	PIDAT   zuviel
-jegliches	jegliches	PIDAT   jeglich
-jeglichen	jeglicher	PIDAT   jeglich
-solchem	solches	PIDAT   solch
-meiste	meistes	PIDAT   meist
-viel	vieles	PIDAT   viel
-zig	zig	PIDAT   zig
-sämtlichen	sämtlich	PIDAT   sämtlich
-allermeisten	allermeisten	PIDAT   allermeisten
-bei-den	beide	PIDAT   beide
-soviel	sovieler	PIDAT   soviel
-wenigste	wenigste	PIDAT   wenigst
-ebensolches	ebensolche	PIDAT   ebensolch
-solchenen	solche_	PIDAT   solch
-#arrel	alles	PIDAT   all
-ebensolchem	ebensolcher	PIDAT   ebensolch
-jedwedem	jedweder	PIDAT   jedwed
-vielem	vieles	PIDAT   viel
-ebensolche	ebensolche	PIDAT   ebensolch
-ebensolchen	ebensolche	PIDAT   ebensolch
-jedem/r	jeder	PIDAT   jed
-solch`	solch	PIDAT   solch
-zuviel	zuviele	PIDAT   zuviel
-ebensovielen	ebensoviele	PIDAT   ebensoviel
-paare	paar	PIDAT   paar
-ebensolcher	ebensolch	PIDAT   ebensolch
-jeglich'm	jeglicher_	PIDAT   jeglich
-gleichviel	gleichvieler	PIDAT   gleichvieler
-jeglich	jegliche	PIDAT   jeglich
-bischen	bißchen	PIDAT   bißchen
+# all unique forms for _ PIDAT
+solche	solche	_	PIDAT   solch
+viele	viele	_	PIDAT   viel
+paar	paar	_	PIDAT   paar
+jeden	jeder	_	PIDAT   jed
+bißchen	bißchen	_	PIDAT   bißchen
+vielen	viele	_	PIDAT   viel
+alle	alle	_	PIDAT   all
+solch	solch	_	PIDAT   solch
+all	all	_	PIDAT   all
+aller	alles	_	PIDAT   all
+wenigen	wenige	_	PIDAT   wenig
+jede	jede	_	PIDAT   jed
+beiden	beide	_	PIDAT   beide
+jedes	jedes	_	PIDAT   jed
+jeder	jeder	_	PIDAT   jed
+beide	beide	_	PIDAT   beide
+jegliche	jegliche	_	PIDAT   jeglich
+solcher	solcher	_	PIDAT   solch
+allen	alle	_	PIDAT   all
+beider	beide	_	PIDAT   beide
+vieler	viele	_	PIDAT   viel
+solchen	solcher	_	PIDAT   solch
+jedem	jedes	_	PIDAT   jed
+wenige	wenige	_	PIDAT   wenig
+alles	alles	_	PIDAT   all
+meisten	meisten	_	PIDAT   meist
+solches	solches	_	PIDAT   solch
+ebensoviele	ebensovieles	_	PIDAT   ebensoviel
+wenig	wenig	_	PIDAT   wenig
+sämtliche	sämtlich	_	PIDAT   sämtlich
+weniger	wenige	_	PIDAT   wenig
+allem	alles	_	PIDAT   all
+jede/r	jeder	_	PIDAT   jed
+jeglichem	jeglicher	_	PIDAT   jeglich
+jedwede	jedwede	_	PIDAT   jedwed
+manch	manch	_	PIDAT   manch
+soviele	sovieles	_	PIDAT   soviel
+jeglicher	jegliche	_	PIDAT   jeglich
+-zig	zig	_	PIDAT   zig
+sämtlicher	sämtlich	_	PIDAT   sämtlich
+jedweder	jedwede	_	PIDAT   jedwed
+sämtliches	sämtlich	_	PIDAT   sämtlich
+wenigsten	wenigste	_	PIDAT   wenigst
+zuviele	zuvieler	_	PIDAT   zuviel
+jegliches	jegliches	_	PIDAT   jeglich
+jeglichen	jeglicher	_	PIDAT   jeglich
+solchem	solches	_	PIDAT   solch
+meiste	meistes	_	PIDAT   meist
+viel	vieles	_	PIDAT   viel
+zig	zig	_	PIDAT   zig
+sämtlichen	sämtlich	_	PIDAT   sämtlich
+allermeisten	allermeisten	_	PIDAT   allermeisten
+bei-den	beide	_	PIDAT   beide
+soviel	sovieler	_	PIDAT   soviel
+wenigste	wenigste	_	PIDAT   wenigst
+ebensolches	ebensolche	_	PIDAT   ebensolch
+solchenen	solche_	_	PIDAT   solch
+#arrel	alles	_	PIDAT   all
+ebensolchem	ebensolcher	_	PIDAT   ebensolch
+jedwedem	jedweder	_	PIDAT   jedwed
+vielem	vieles	_	PIDAT   viel
+ebensolche	ebensolche	_	PIDAT   ebensolch
+ebensolchen	ebensolche	_	PIDAT   ebensolch
+jedem/r	jeder	_	PIDAT   jed
+solch`	solch	_	PIDAT   solch
+zuviel	zuviele	_	PIDAT   zuviel
+ebensovielen	ebensoviele	_	PIDAT   ebensoviel
+paare	paar	_	PIDAT   paar
+ebensolcher	ebensolch	_	PIDAT   ebensolch
+jeglich'm	jeglicher_	_	PIDAT   jeglich
+gleichviel	gleichvieler	_	PIDAT   gleichvieler
+jeglich	jegliche	_	PIDAT   jeglich
+bischen	bißchen	_	PIDAT   bißchen

--- a/ohnomore/testdata/simplify-pis-lemma.test
+++ b/ohnomore/testdata/simplify-pis-lemma.test
@@ -1,163 +1,163 @@
-alle	alle	PIS alle
-anderen	anderer	PIS ander
-was	etwas	PIS etwas
-nichts	nichts	PIS nichts
-etwas	etwas	PIS etwas
-allem	alles	PIS alle
-alles	alles	PIS alle
-mehr	mehr	PIS mehr
-wenig	wenig	PIS wenig
-man	man	PIS man
-bißchen	bißchen	PIS bißchen
-einer	einer	PIS ein
-nix	nichts	PIS nichts
-meisten	meisten	PIS meist
-viele	viele	PIS viel
-jeder	jeder	PIS jed
-beide	beide	PIS beid
-beides	beides	PIS beid
-eine	eine	PIS ein
-ebensoviel	ebensoviel	PIS ebensoviel
-niemanden	niemand	PIS niemand
-anderes	anderes	PIS ander
-einen	einer	PIS ein
-beiden	beide	PIS beid
-jemand	jemand	PIS jemand
-letztere	letzterer	PIS letzter
-solchen	solcher	PIS solch
-andere	anderer	PIS ander
-keine	keine	PIS kein
-einem	einer	PIS ein
-eines	eines	PIS ein
-viel	viel	PIS viel
-einiges	einiges	PIS einig
-jeden	jeder	PIS jed
-niemand	niemand	PIS niemand
-anderem	anderes	PIS ander
-vielen	viele	PIS viel
-genug	genug	PIS genug
-irgendwer	irgendwer	PIS irgendwer
-keiner	keiner	PIS kein
-letzterem	letzterer	PIS letzter
-wenige	wenige	PIS wenig
-einige	einige	PIS einig
-ihresgleichen	ihresgleichen	PIS ihresgleichen
-allen	alle	PIS alle
-vieles	vieles	PIS viel
-sowas	sowas	PIS sowas
-manches	manches	PIS manch
-seinesgleichen	seinesgleichen	PIS seinesgleichen
-mancher	mancher	PIS manch
-meiste	meistes	PIS meist
-manche	mancher	PIS manch
-eins	eines	PIS ein
-a.	a.	PIS a.
-einiger	einige	PIS einig
-soviel	soviel	PIS soviel
-niemandem	niemand	PIS niemand
-keinem	keiner	PIS kein
-irgendwen	irgendwer	PIS irgendwer
-irgendwas	irgendetwas	PIS irgendetwas
-allzuviel	allzuviel	PIS allzuviel
-jedes	jedes	PIS jed
-solche	solcher	PIS solch
-weniger	weniger	PIS wenig
-jedem	jeder	PIS jed
-keinen	keiner	PIS kein
-keines	keines	PIS kein
-jemanden	jemand	PIS jemand
-frau	frau	PIS frau
-solches	solches	PIS solch
-derlei	derlei	PIS derlei
-mehrere	mehrere	PIS mehrere
-aller	alle	PIS alle
-paar	paar	PIS paar
-jemandem	jemand	PIS jemand
-wenigsten	wenigst	PIS wenigst
-alledem	alledem	PIS alledem
-genausoviel	genausoviel	PIS genausoviel
-jede(r)	jeder	PIS jed
-anderer	anderer	PIS ander
-manchem	mancher	PIS manch
-wenigen	wenige	PIS wenig
-ersteres	ersteres	PIS erster
-einzige	einziger	PIS einzig
-irgendwem	irgendwer	PIS irgendwer
-allerhand	allerhand	PIS allerhand
-solcher	solcher	PIS solch
-letzteres	letzteres	PIS letzter
-andern	anderes	PIS ander
-zuwenig	zuwenig	PIS zuwenig
-ersterer	ersterer	PIS erster
-letzteren	letzterer	PIS letzter
-zuviel	zuviel	PIS zuviel
-irgendjemand	irgendjemand	PIS irgendjemand
-vieler	viele	PIS viel
-anders	anderes	PIS ander
-unsereins	unsereins	PIS unsereins
-zweierlei	zweierlei	PIS zweierlei
-einigen	einige	PIS einig
-manchen	mancher	PIS manch
-jede	jede	PIS jed
-einziger	einziger	PIS einzig
-jedermann	jedermann	PIS jederman
-irgendetwas	irgendetwas	PIS irgendetwas
-mensch	mensch	PIS mensch
-etliche	etliche	PIS etlich
-allermeisten	allermeisten	PIS allermeisten
-irgendjemanden	irgendjemand	PIS irgendjemand
-allerlei	allerlei	PIS allerlei
--frau	jedefrau	PIS jedefrau
-mann	mann	PIS mann
-nicht	nichts	PIS nichts
-letzterer	letzterer	PIS letzter
-unsereinem	unsereiner	PIS unsereiner
-etlichen	etliche	PIS etlich
-andre	anderer	PIS ander
-genausowenig	genausowenig	PIS genausowenig
-beidem	beides	PIS beid
-niemand's	niemand	PIS niemand
-an	man	PIS man
-vielem	vieles	PIS viel
-jederman	jedermann	PIS jederman
-bisserl	bißchen_	PIS bißchen_
-ma	man_	PIS man_
-irgendeine	irgendeine	PIS irgendein
-üllus	alles_	PIS alles_
-keins	keines	PIS kein
-ein	eines	PIS ein
-man(n)	man	PIS man
-erstere	ersterer	PIS erster
-einzigen	einziger	PIS einzig
-anderm	anderes	PIS ander
-irgendeinen	irgendeiner	PIS irgendein
-irgendeiner	irgendeiner	PIS irgendein
-ebensolchen	ebensolcher	PIS ebensolcher
-irgendeins	irgendeines	PIS irgendein
-dergleichen	dergleichen	PIS dergleichen
-unseresgleichen	unseresgleichen	PIS unseresgleichen
-wenigstens	wenigst	PIS wenigst
-spottwenig	spottwenig	PIS spottwenig
-wat	etwas_	PIS etwas_
-ersteren	ersterer	PIS erster
-mehreren	mehrere	PIS mehrere
-etliches	etliches	PIS etlich
-sonstwas	sonstwas	PIS sonstwas
-einzelnen	einzelner	PIS einzeln
-nüscht	nichts_	PIS nichts_
-sonstwen	sonstwer	PIS sonstwer
-jede/r	jeder	PIS jed
-bissl	bißchen_	PIS bißchen_
-koaner	keiner_	PIS keiner_
-ois	alles_	PIS alles_
-einzelne	einzelner	PIS einzeln
-ebensowenig	ebensowenig	PIS ebensowenig
-letzeres	letzeres	PIS letzeres
-zuviele	zuviele	PIS zuviel
-kein	keiner	PIS kein
-zig	zig	PIS zig
-soviele	soviele	PIS soviel
-allis	alles	PIS alles
-beider	beide	PIS beid
-wos	etwas_	PIS etwas_
-dreierlei	dreierlei	PIS dreierlei
+alle	alle	_	PIS alle
+anderen	anderer	_	PIS ander
+was	etwas	_	PIS etwas
+nichts	nichts	_	PIS nichts
+etwas	etwas	_	PIS etwas
+allem	alles	_	PIS alle
+alles	alles	_	PIS alle
+mehr	mehr	_	PIS mehr
+wenig	wenig	_	PIS wenig
+man	man	_	PIS man
+bißchen	bißchen	_	PIS bißchen
+einer	einer	_	PIS ein
+nix	nichts	_	PIS nichts
+meisten	meisten	_	PIS meist
+viele	viele	_	PIS viel
+jeder	jeder	_	PIS jed
+beide	beide	_	PIS beid
+beides	beides	_	PIS beid
+eine	eine	_	PIS ein
+ebensoviel	ebensoviel	_	PIS ebensoviel
+niemanden	niemand	_	PIS niemand
+anderes	anderes	_	PIS ander
+einen	einer	_	PIS ein
+beiden	beide	_	PIS beid
+jemand	jemand	_	PIS jemand
+letztere	letzterer	_	PIS letzter
+solchen	solcher	_	PIS solch
+andere	anderer	_	PIS ander
+keine	keine	_	PIS kein
+einem	einer	_	PIS ein
+eines	eines	_	PIS ein
+viel	viel	_	PIS viel
+einiges	einiges	_	PIS einig
+jeden	jeder	_	PIS jed
+niemand	niemand	_	PIS niemand
+anderem	anderes	_	PIS ander
+vielen	viele	_	PIS viel
+genug	genug	_	PIS genug
+irgendwer	irgendwer	_	PIS irgendwer
+keiner	keiner	_	PIS kein
+letzterem	letzterer	_	PIS letzter
+wenige	wenige	_	PIS wenig
+einige	einige	_	PIS einig
+ihresgleichen	ihresgleichen	_	PIS ihresgleichen
+allen	alle	_	PIS alle
+vieles	vieles	_	PIS viel
+sowas	sowas	_	PIS sowas
+manches	manches	_	PIS manch
+seinesgleichen	seinesgleichen	_	PIS seinesgleichen
+mancher	mancher	_	PIS manch
+meiste	meistes	_	PIS meist
+manche	mancher	_	PIS manch
+eins	eines	_	PIS ein
+a.	a.	_	PIS a.
+einiger	einige	_	PIS einig
+soviel	soviel	_	PIS soviel
+niemandem	niemand	_	PIS niemand
+keinem	keiner	_	PIS kein
+irgendwen	irgendwer	_	PIS irgendwer
+irgendwas	irgendetwas	_	PIS irgendetwas
+allzuviel	allzuviel	_	PIS allzuviel
+jedes	jedes	_	PIS jed
+solche	solcher	_	PIS solch
+weniger	weniger	_	PIS wenig
+jedem	jeder	_	PIS jed
+keinen	keiner	_	PIS kein
+keines	keines	_	PIS kein
+jemanden	jemand	_	PIS jemand
+frau	frau	_	PIS frau
+solches	solches	_	PIS solch
+derlei	derlei	_	PIS derlei
+mehrere	mehrere	_	PIS mehrere
+aller	alle	_	PIS alle
+paar	paar	_	PIS paar
+jemandem	jemand	_	PIS jemand
+wenigsten	wenigst	_	PIS wenigst
+alledem	alledem	_	PIS alledem
+genausoviel	genausoviel	_	PIS genausoviel
+jede(r)	jeder	_	PIS jed
+anderer	anderer	_	PIS ander
+manchem	mancher	_	PIS manch
+wenigen	wenige	_	PIS wenig
+ersteres	ersteres	_	PIS erster
+einzige	einziger	_	PIS einzig
+irgendwem	irgendwer	_	PIS irgendwer
+allerhand	allerhand	_	PIS allerhand
+solcher	solcher	_	PIS solch
+letzteres	letzteres	_	PIS letzter
+andern	anderes	_	PIS ander
+zuwenig	zuwenig	_	PIS zuwenig
+ersterer	ersterer	_	PIS erster
+letzteren	letzterer	_	PIS letzter
+zuviel	zuviel	_	PIS zuviel
+irgendjemand	irgendjemand	_	PIS irgendjemand
+vieler	viele	_	PIS viel
+anders	anderes	_	PIS ander
+unsereins	unsereins	_	PIS unsereins
+zweierlei	zweierlei	_	PIS zweierlei
+einigen	einige	_	PIS einig
+manchen	mancher	_	PIS manch
+jede	jede	_	PIS jed
+einziger	einziger	_	PIS einzig
+jedermann	jedermann	_	PIS jederman
+irgendetwas	irgendetwas	_	PIS irgendetwas
+mensch	mensch	_	PIS mensch
+etliche	etliche	_	PIS etlich
+allermeisten	allermeisten	_	PIS allermeisten
+irgendjemanden	irgendjemand	_	PIS irgendjemand
+allerlei	allerlei	_	PIS allerlei
+-frau	jedefrau	_	PIS jedefrau
+mann	mann	_	PIS mann
+nicht	nichts	_	PIS nichts
+letzterer	letzterer	_	PIS letzter
+unsereinem	unsereiner	_	PIS unsereiner
+etlichen	etliche	_	PIS etlich
+andre	anderer	_	PIS ander
+genausowenig	genausowenig	_	PIS genausowenig
+beidem	beides	_	PIS beid
+niemand's	niemand	_	PIS niemand
+an	man	_	PIS man
+vielem	vieles	_	PIS viel
+jederman	jedermann	_	PIS jederman
+bisserl	bißchen_	_	PIS bißchen_
+ma	man_	_	PIS man_
+irgendeine	irgendeine	_	PIS irgendein
+üllus	alles_	_	PIS alles_
+keins	keines	_	PIS kein
+ein	eines	_	PIS ein
+man(n)	man	_	PIS man
+erstere	ersterer	_	PIS erster
+einzigen	einziger	_	PIS einzig
+anderm	anderes	_	PIS ander
+irgendeinen	irgendeiner	_	PIS irgendein
+irgendeiner	irgendeiner	_	PIS irgendein
+ebensolchen	ebensolcher	_	PIS ebensolcher
+irgendeins	irgendeines	_	PIS irgendein
+dergleichen	dergleichen	_	PIS dergleichen
+unseresgleichen	unseresgleichen	_	PIS unseresgleichen
+wenigstens	wenigst	_	PIS wenigst
+spottwenig	spottwenig	_	PIS spottwenig
+wat	etwas_	_	PIS etwas_
+ersteren	ersterer	_	PIS erster
+mehreren	mehrere	_	PIS mehrere
+etliches	etliches	_	PIS etlich
+sonstwas	sonstwas	_	PIS sonstwas
+einzelnen	einzelner	_	PIS einzeln
+nüscht	nichts_	_	PIS nichts_
+sonstwen	sonstwer	_	PIS sonstwer
+jede/r	jeder	_	PIS jed
+bissl	bißchen_	_	PIS bißchen_
+koaner	keiner_	_	PIS keiner_
+ois	alles_	_	PIS alles_
+einzelne	einzelner	_	PIS einzeln
+ebensowenig	ebensowenig	_	PIS ebensowenig
+letzeres	letzeres	_	PIS letzeres
+zuviele	zuviele	_	PIS zuviel
+kein	keiner	_	PIS kein
+zig	zig	_	PIS zig
+soviele	soviele	_	PIS soviel
+allis	alles	_	PIS alles
+beider	beide	_	PIS beid
+wos	etwas_	_	PIS etwas_
+dreierlei	dreierlei	_	PIS dreierlei

--- a/ohnomore/testdata/simplify-possesive-pronoun-lemma.test
+++ b/ohnomore/testdata/simplify-possesive-pronoun-lemma.test
@@ -1,44 +1,44 @@
-# Format: form lemma pos transformed [rel head_form head_lemma head_pos]
-#   [rel dep_form dep_lemma dep_pos]*
+# Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
+#   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
 # Substituting possesive pronouns
-Ihre     _ PPOSS ihr
-ihre     _ PPOSS ihr
-meine    _ PPOSS mein
-meinen   _ PPOSS mein
-deines   _ PPOSS dein
-seine    _ PPOSS sein
-seinen   _ PPOSS sein
-unsere   _ PPOSS unser
-unsern   _ PPOSS unser
-unsrige  _ PPOSS unsrig
-unsrigen _ PPOSS unsrig
+Ihre     _ _ PPOSS ihr
+ihre     _ _ PPOSS ihr
+meine    _ _ PPOSS mein
+meinen   _ _ PPOSS mein
+deines   _ _ PPOSS dein
+seine    _ _ PPOSS sein
+seinen   _ _ PPOSS sein
+unsere   _ _ PPOSS unser
+unsern   _ _ PPOSS unser
+unsrige  _ _ PPOSS unsrig
+unsrigen _ _ PPOSS unsrig
 
 # Attributive possesive pronouns
-dein    _ PPOSAT dein
-deine   _ PPOSAT dein
-euer    _ PPOSAT euer
-eure    _ PPOSAT euer
-euren   _ PPOSAT euer
-ihr     _ PPOSAT ihr
-ihrem   _ PPOSAT ihr
-Ihre    _ PPOSAT ihr
-Ihrem   _ PPOSAT ihr
-mein    _ PPOSAT mein
-meine   _ PPOSAT mein
-meinem  _ PPOSAT mein
-sein    _ PPOSAT sein
-seine   _ PPOSAT sein
-seinem  _ PPOSAT sein
-seinen  _ PPOSAT sein
-unser   _ PPOSAT unser
-unsere  _ PPOSAT unser
-unserem _ PPOSAT unser
+dein    _ _ PPOSAT dein
+deine   _ _ PPOSAT dein
+euer    _ _ PPOSAT euer
+eure    _ _ PPOSAT euer
+euren   _ _ PPOSAT euer
+ihr     _ _ PPOSAT ihr
+ihrem   _ _ PPOSAT ihr
+Ihre    _ _ PPOSAT ihr
+Ihrem   _ _ PPOSAT ihr
+mein    _ _ PPOSAT mein
+meine   _ _ PPOSAT mein
+meinem  _ _ PPOSAT mein
+sein    _ _ PPOSAT sein
+seine   _ _ PPOSAT sein
+seinem  _ _ PPOSAT sein
+seinen  _ _ PPOSAT sein
+unser   _ _ PPOSAT unser
+unsere  _ _ PPOSAT unser
+unserem _ _ PPOSAT unser
 
 # Use the lemma when the prefix is unknown
-unsre unsere PPOSAT unsere
+unsre unsere _ PPOSAT unsere
 
 # Exclude other tags
-Ihre    foo XY foo
-ihre    bar XY bar
-unserem baz XY baz
+Ihre    foo _ XY foo
+ihre    bar _ XY bar
+unserem baz _ XY baz


### PR DESCRIPTION
Before this change, only the XPOS tag could be used.