### PR TITLE
Use UPOS to decide whether to lowercase truncations

### DIFF
--- a/ohnomore/src/transform/delemmatization.rs
+++ b/ohnomore/src/transform/delemmatization.rs
@@ -94,21 +94,15 @@ impl Transform for RemoveTruncMarker {
         let token = graph.token(node);
         let lemma = token.lemma();
 
-        if token.xpos() == TRUNCATED_TAG {
-            if let Some(idx) = lemma.rfind('%') {
-                let tag = &lemma[idx + 1..];
-
-                let form = if tag == "n" {
-                    token.form().to_owned()
-                } else {
-                    token.form().to_lowercase()
-                };
-
-                return form;
-            }
+        if token.xpos() != TRUNCATED_TAG {
+            return lemma.to_owned();
         }
 
-        lemma.to_owned()
+        if token.upos() == "NOUN" {
+            token.form().to_owned()
+        } else {
+            token.form().to_lowercase()
+        }
     }
 }
 

--- a/ohnomore/testdata/remove-trunc-marker.test
+++ b/ohnomore/testdata/remove-trunc-marker.test
@@ -1,10 +1,10 @@
 # Format: form lemma upos xpos transformed [rel head_form head_lemma head_upos head_xpos]
 #   [rel dep_form dep_lemma dep_upos dep_xpos]*
 
-Bau-   Bauplanung%n   _ TRUNC Bau-
-jahre- jahrelang%a    _ TRUNC jahre-
-Jahre- jahrelang%a    _ TRUNC jahre-
-hin-   hin#schieben%v _ TRUNC hin-
+Bau-   Bauplanung   NOUN TRUNC Bau-
+jahre- jahrelang    ADJ TRUNC jahre-
+Jahre- jahrelang    ADJ TRUNC jahre-
+hin-   hin#schieben VERB TRUNC hin-
 
 # Should not fire for other tags
-Bau- Bauplanung%n _ XYZ Bauplanung%n
+Bau- foo NOUN XYZ foo


### PR DESCRIPTION
This rule did not fire for the CoNLL-U Tueba-D/Z, since it expected a
percentage sign in the lemma. However, the part-of-speech is not
encoded in the lemma in the CoNLL-U version. So, we always use the
form as the lemma for truncations and rely on the UPOS tag to decide
whether to lowercase the lemma.